### PR TITLE
Wait after deployment before querying the endpoint.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ jobs:
       - run:
           name: call endpoint and check output
           command: |
+            sleep 60  # Wait for initialization after deployment.
             curl https://$GOOGLE_PROJECT_ID.appspot.com/spanner | tee $HOME/output.html
             grep -q "All done!" $HOME/output.html
 


### PR DESCRIPTION
Attempt to deflake the integration test. Apparently App Engine takes a
while after deployment to get ready, resulting in a 500 error.